### PR TITLE
Disable filter when in cp, api or graphql

### DIFF
--- a/src/Middleware/FilterOutQueryStrings.php
+++ b/src/Middleware/FilterOutQueryStrings.php
@@ -23,8 +23,11 @@ class FilterOutQueryStrings
 
     public function handle(Request $request, Closure $next)
     {
-
         if (!$this->isStaticCachingOn) {
+            return $next($request);
+        }
+
+        if($request->is('cp/*') || $request->is('api/*') || $request->is('graphql/*')) {
             return $next($request);
         }
 


### PR DESCRIPTION
There is basically no case that you want to filter out parameters in the CP, API or Graphql. When using mode "allow" it even breaks. With checking the request for these paths, it continues to work.

Thanks for sharing this addon! It really helped us out with handling the many many Google crawler requests. Because of this, we had like >100.000 static cache pages (crawling filtered overview pages), but we only have a couple of thousand actual pages.