### PR TITLE
Revert "Disable filter when in cp, api or graphql"

### DIFF
--- a/src/Middleware/FilterOutQueryStrings.php
+++ b/src/Middleware/FilterOutQueryStrings.php
@@ -23,11 +23,8 @@ class FilterOutQueryStrings
 
     public function handle(Request $request, Closure $next)
     {
-        if (!$this->isStaticCachingOn) {
-            return $next($request);
-        }
 
-        if($request->is('cp/*') || $request->is('api/*') || $request->is('graphql/*')) {
+        if (!$this->isStaticCachingOn) {
             return $next($request);
         }
 


### PR DESCRIPTION
Hardcoding these paths is bad idea ...
Reverts 4dmind/ignore-query-strings#4